### PR TITLE
Fixed prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,9 @@ function get(object, path, joiner) {
  * @param joiner
  */
 function set(object, path, value, initPaths, joiner) {
+  if (path.includes('__proto__') || path.includes('prototype') || path.includes('constructor')){
+    return false
+  }
   if (!isObject(object)) return false;
   var keys = path.split(joiner || '.');
 


### PR DESCRIPTION
### Description
Affected versions of this package are vulnerable to ```Prototype Pollution``` via the ```set``` function.
Bug referance: https://snyk.io/vuln/SNYK-JS-DEEPS-598667

### Proof-of-Concept
```
const deeps = require('deeps');
deeps.set({}, '__proto__.polluted', true);
console.log(polluted); \\true
```

### Proof-of-Fix
Filtered the keywords causing prototype pollution from path. This includes ```__proto__```, ```prototype``` and ```constructor```. 
Run the poc again no polluted variable.